### PR TITLE
Outline-Navigation-US(#32)

### DIFF
--- a/src/components/Editor/extensions/markdown-heading-fold.ts
+++ b/src/components/Editor/extensions/markdown-heading-fold.ts
@@ -15,6 +15,9 @@ import {
     type ViewUpdate,
     WidgetType,
 } from "@codemirror/view";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ChevronRight } from "lucide-react";
 
 const HEADING_NODE_RE = /^ATXHeading([1-6])$/;
 const HEADING_FOLD_COLUMN_WIDTH = "1.5rem";
@@ -80,6 +83,8 @@ function isHeadingFolded(state: EditorState, foldRange: { from: number; to: numb
 }
 
 class HeadingFoldWidget extends WidgetType {
+    private iconRoot: Root | null = null;
+
     constructor(
         private readonly foldRange: { from: number; to: number },
         private readonly isFolded: boolean
@@ -95,6 +100,28 @@ class HeadingFoldWidget extends WidgetType {
         );
     }
 
+    private applyButtonState(button: HTMLButtonElement): void {
+        button.classList.toggle("is-expanded", !this.isFolded);
+        button.setAttribute("aria-expanded", (!this.isFolded).toString());
+        button.setAttribute("aria-label", this.isFolded ? "Expand heading" : "Collapse heading");
+    }
+
+    private attachToggleHandler(button: HTMLButtonElement, view: EditorView): void {
+        button.onclick = (event) => {
+            event.preventDefault();
+
+            // Toggle visual state immediately so the chevron transition is perceptible.
+            const isExpanded = button.classList.contains("is-expanded");
+            const nextExpanded = !isExpanded;
+            button.classList.toggle("is-expanded", nextExpanded);
+            button.setAttribute("aria-expanded", String(nextExpanded));
+            button.setAttribute("aria-label", nextExpanded ? "Collapse heading" : "Expand heading");
+
+            const effect = isExpanded ? foldEffect.of(this.foldRange) : unfoldEffect.of(this.foldRange);
+            view.dispatch({ effects: effect });
+        };
+    }
+
     toDOM(view: EditorView): HTMLElement {
         const marker = document.createElement("span");
         marker.className = "cm-heading-fold-marker";
@@ -103,15 +130,39 @@ class HeadingFoldWidget extends WidgetType {
         const button = document.createElement("button");
         button.type = "button";
         button.className = "cm-heading-fold-toggle";
-        button.textContent = this.isFolded ? "▸" : "▾";
-        button.setAttribute("aria-label", this.isFolded ? "Expand heading" : "Collapse heading");
-        button.onclick = (event) => {
-            event.preventDefault();
-            const effect = this.isFolded ? unfoldEffect.of(this.foldRange) : foldEffect.of(this.foldRange);
-            view.dispatch({ effects: effect });
-        };
+        this.applyButtonState(button);
+
+        const iconContainer = document.createElement("span");
+        iconContainer.className = "cm-heading-fold-icon";
+        this.iconRoot = createRoot(iconContainer);
+        this.iconRoot.render(
+            createElement(ChevronRight, {
+                size: 14,
+                strokeWidth: 2,
+                "aria-hidden": true,
+            })
+        );
+        button.appendChild(iconContainer);
+
+        this.attachToggleHandler(button, view);
         marker.appendChild(button);
         return marker;
+    }
+
+    updateDOM(dom: HTMLElement, view: EditorView): boolean {
+        const button = dom.querySelector(".cm-heading-fold-toggle");
+        if (!(button instanceof HTMLButtonElement)) {
+            return false;
+        }
+
+        this.applyButtonState(button);
+        this.attachToggleHandler(button, view);
+        return true;
+    }
+
+    destroy(): void {
+        this.iconRoot?.unmount();
+        this.iconRoot = null;
     }
 
     ignoreEvent(): boolean {
@@ -173,9 +224,38 @@ const headingFoldWidgetTheme = EditorView.baseTheme({
         margin: "0",
         padding: "0",
         pointerEvents: "auto",
+        transition: "color 200ms ease-in-out",
+    },
+    ".cm-heading-fold-icon": {
+        display: "inline-flex",
+        lineHeight: 0,
+        transition: "transform 200ms ease-in-out",
+        transform: "rotate(-90deg)",
+        willChange: "transform",
+    },
+    ".cm-heading-fold-toggle.is-expanded .cm-heading-fold-icon": {
+        transform: "rotate(0deg)",
+    },
+    ".cm-heading-fold-icon svg": {
+        width: "0.875rem",
+        height: "0.875rem",
     },
     ".cm-heading-fold-toggle:hover": {
         color: "var(--color-text-primary)",
+    },
+    ":root[data-reduced-motion='true'] .cm-heading-fold-toggle": {
+        transition: "none",
+    },
+    ":root[data-reduced-motion='true'] .cm-heading-fold-icon": {
+        transition: "none",
+    },
+    "@media (prefers-reduced-motion: reduce)": {
+        ".cm-heading-fold-toggle": {
+            transition: "none",
+        },
+        ".cm-heading-fold-icon": {
+            transition: "none",
+        },
     },
 });
 

--- a/src/components/Editor/extensions/markdown-heading-fold.ts
+++ b/src/components/Editor/extensions/markdown-heading-fold.ts
@@ -1,0 +1,206 @@
+import { EditorState, RangeSetBuilder, type Extension } from "@codemirror/state";
+import {
+    codeFolding,
+    foldState,
+    foldService,
+    syntaxTree,
+    unfoldEffect,
+    foldEffect,
+} from "@codemirror/language";
+import {
+    Decoration,
+    EditorView,
+    ViewPlugin,
+    type DecorationSet,
+    type ViewUpdate,
+    WidgetType,
+} from "@codemirror/view";
+
+const HEADING_NODE_RE = /^ATXHeading([1-6])$/;
+const HEADING_FOLD_COLUMN_WIDTH = "1.5rem";
+const HEADING_FOLD_MARKER_OFFSET = `-${HEADING_FOLD_COLUMN_WIDTH}`;
+
+function getTopLevelMarkdownHeadingLevel(state: EditorState, lineNumber: number): number | null {
+    const line = state.doc.line(lineNumber);
+    let node: ReturnType<typeof syntaxTree>["topNode"] | null = syntaxTree(state).resolveInner(line.from, 1);
+
+    while (node) {
+        const match = node.name.match(HEADING_NODE_RE);
+        if (match) {
+            return node.parent?.name === "Document" ? Number(match[1]) : null;
+        }
+        node = node.parent;
+    }
+
+    return null;
+}
+
+function getFoldEndLineNumber(state: EditorState, startLineNumber: number, startLevel: number): number {
+    for (let lineNumber = startLineNumber + 1; lineNumber <= state.doc.lines; lineNumber++) {
+        const level = getTopLevelMarkdownHeadingLevel(state, lineNumber);
+        if (level !== null && level <= startLevel) {
+            return lineNumber - 1;
+        }
+    }
+
+    return state.doc.lines;
+}
+
+function getMarkdownHeadingFoldRange(state: EditorState, lineStart: number) {
+    const line = state.doc.lineAt(lineStart);
+    const level = getTopLevelMarkdownHeadingLevel(state, line.number);
+
+    if (level === null) {
+        return null;
+    }
+
+    const endLineNumber = getFoldEndLineNumber(state, line.number, level);
+    const endLine = state.doc.line(endLineNumber);
+
+    if (endLine.to <= line.to) {
+        return null;
+    }
+
+    return {
+        from: line.to,
+        to: endLine.to,
+    };
+}
+
+function isHeadingFolded(state: EditorState, foldRange: { from: number; to: number }): boolean {
+    let folded = false;
+
+    state.field(foldState, false)?.between(foldRange.from, foldRange.to, (from, to) => {
+        if (from === foldRange.from && to === foldRange.to) {
+            folded = true;
+        }
+    });
+
+    return folded;
+}
+
+class HeadingFoldWidget extends WidgetType {
+    constructor(
+        private readonly foldRange: { from: number; to: number },
+        private readonly isFolded: boolean
+    ) {
+        super();
+    }
+
+    eq(other: HeadingFoldWidget): boolean {
+        return (
+            other.foldRange.from === this.foldRange.from &&
+            other.foldRange.to === this.foldRange.to &&
+            other.isFolded === this.isFolded
+        );
+    }
+
+    toDOM(view: EditorView): HTMLElement {
+        const marker = document.createElement("span");
+        marker.className = "cm-heading-fold-marker";
+        marker.style.left = HEADING_FOLD_MARKER_OFFSET;
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "cm-heading-fold-toggle";
+        button.textContent = this.isFolded ? "▸" : "▾";
+        button.setAttribute("aria-label", this.isFolded ? "Expand heading" : "Collapse heading");
+        button.onclick = (event) => {
+            event.preventDefault();
+            const effect = this.isFolded ? unfoldEffect.of(this.foldRange) : foldEffect.of(this.foldRange);
+            view.dispatch({ effects: effect });
+        };
+        marker.appendChild(button);
+        return marker;
+    }
+
+    ignoreEvent(): boolean {
+        return false;
+    }
+}
+
+function buildHeadingFoldDecorations(view: EditorView): DecorationSet {
+    const builder = new RangeSetBuilder<Decoration>();
+
+    for (let lineNumber = 1; lineNumber <= view.state.doc.lines; lineNumber++) {
+        const line = view.state.doc.line(lineNumber);
+        const foldRange = getMarkdownHeadingFoldRange(view.state, line.from);
+
+        if (!foldRange) {
+            continue;
+        }
+
+        const isFolded = isHeadingFolded(view.state, foldRange);
+        builder.add(
+            line.from,
+            line.from,
+            Decoration.line({ class: "cm-heading-fold-line" })
+        );
+        builder.add(
+            line.from,
+            line.from,
+            Decoration.widget({
+                widget: new HeadingFoldWidget(foldRange, isFolded),
+                side: 0,
+            })
+        );
+    }
+
+    return builder.finish();
+}
+
+const headingFoldWidgetTheme = EditorView.baseTheme({
+    ".cm-heading-fold-line": {
+        position: "relative",
+        overflow: "visible",
+    },
+    ".cm-heading-fold-marker": {
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(-50%)",
+        pointerEvents: "none",
+    },
+    ".cm-heading-fold-toggle": {
+        border: "none",
+        background: "transparent",
+        color: "var(--color-text-muted)",
+        cursor: "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "1rem",
+        height: "1rem",
+        margin: "0",
+        padding: "0",
+        pointerEvents: "auto",
+    },
+    ".cm-heading-fold-toggle:hover": {
+        color: "var(--color-text-primary)",
+    },
+});
+
+const headingFoldWidgetPlugin = ViewPlugin.fromClass(
+    class {
+        decorations: DecorationSet;
+
+        constructor(view: EditorView) {
+            this.decorations = buildHeadingFoldDecorations(view);
+        }
+
+        update(update: ViewUpdate) {
+            if (update.docChanged || update.viewportChanged || update.selectionSet || update.transactions.length > 0) {
+                this.decorations = buildHeadingFoldDecorations(update.view);
+            }
+        }
+    },
+    {
+        decorations: (value) => value.decorations,
+    }
+);
+
+export const markdownHeadingFoldExtension: Extension = [
+    codeFolding(),
+    foldService.of((state, lineStart) => getMarkdownHeadingFoldRange(state, lineStart)),
+    headingFoldWidgetTheme,
+    headingFoldWidgetPlugin,
+];

--- a/src/components/Editor/hooks/useEditorActions.ts
+++ b/src/components/Editor/hooks/useEditorActions.ts
@@ -37,6 +37,12 @@ export function useFileSynchronization(activeNote: FileMetadata | null) {
         loadRequestIdRef.current = requestId;
         let cancelled = false;
 
+        // Clear stale content immediately so dependent UI, including the outline,
+        // does not render the previous note while the new note is loading.
+        setContent("");
+        setActiveNoteContent("");
+        setIsDirty(false);
+
         const load = async () => {
             try {
                 setIsLoading(true);

--- a/src/components/Editor/hooks/useEditorExtensions.ts
+++ b/src/components/Editor/hooks/useEditorExtensions.ts
@@ -3,6 +3,7 @@ import { EditorView } from "@codemirror/view";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { TessellumApp } from "../../../plugins/TessellumApp";
+import { markdownHeadingFoldExtension } from "../extensions/markdown-heading-fold";
 
 const markdownCloseBracketsExtension = markdownLanguage.data.of({
     closeBrackets: {
@@ -25,6 +26,7 @@ export function useEditorExtensions() {
         return [
             markdown({ base: markdownLanguage, codeLanguages: languages }),
             markdownCloseBracketsExtension,
+            markdownHeadingFoldExtension,
             EditorView.lineWrapping,
             ...app.editor.getInitialExtensions(),
         ];

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Text } from "@codemirror/state";
-import { Link2, List, Tag } from "lucide-react";
+import { ChevronDown, ChevronRight, Link2, List, Tag } from "lucide-react";
 import { theme } from "../../styles/theme";
 import { BaseSidebar } from "./BaseSidebar";
 import { cn } from "../../lib/utils";
@@ -10,6 +10,7 @@ import { useTessellumApp } from "../../plugins/TessellumApp";
 import { useResizableSidebarWidth } from "./useResizableSidebarWidth";
 import { parseFrontmatter } from "../Editor/extensions/frontmatter/frontmatter-parser";
 import { stringToColor } from "../../utils/graphUtils";
+import { parseOutline } from "../../utils/outline";
 
 const SNIPPET_LIMIT = 20;
 const SNIPPET_MAX_LEN = 120;
@@ -354,19 +355,134 @@ function TagsSection({ activeNote, tags }: { activeNote: { path: string } | null
     );
 }
 
-function OutlineSection() {
+function getOutlineIndent(level: number): string {
+    return `calc(0.5rem + ${Math.max(level - 1, 0) * 0.875}rem)`;
+}
+
+function getOutlineKey(title: string, lineNumber: number): string {
+    return `${lineNumber}:${title}`;
+}
+
+function hasNestedChildren(items: ReturnType<typeof parseOutline>, index: number): boolean {
+    const currentLevel = items[index]?.level ?? 0;
+    const nextLevel = items[index + 1]?.level ?? 0;
+    return nextLevel > currentLevel;
+}
+
+function getVisibleOutlineItems(
+    items: ReturnType<typeof parseOutline>,
+    collapsedKeys: Set<string>
+) {
+    const hiddenLevels: number[] = [];
+
+    return items.filter((item) => {
+        while (hiddenLevels.length > 0 && item.level <= hiddenLevels[hiddenLevels.length - 1]) {
+            hiddenLevels.pop();
+        }
+
+        if (hiddenLevels.length > 0) {
+            return false;
+        }
+
+        if (collapsedKeys.has(getOutlineKey(item.title, item.lineNumber))) {
+            hiddenLevels.push(item.level);
+        }
+
+        return true;
+    });
+}
+
+function OutlineSection({
+                            activeNote,
+                            activeNoteContent,
+                            onNavigate,
+                        }: {
+    activeNote: { path: string } | null;
+    activeNoteContent?: string;
+    onNavigate: (lineNumber: number) => void;
+}) {
+    const outlineItems = useMemo(() => parseOutline(activeNoteContent ?? ""), [activeNoteContent]);
+    const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
+    const visibleOutlineItems = useMemo(
+        () => getVisibleOutlineItems(outlineItems, collapsedKeys),
+        [outlineItems, collapsedKeys]
+    );
+
+    useEffect(() => {
+        setCollapsedKeys(new Set());
+    }, [activeNote?.path, activeNoteContent]);
+
+    function toggleCollapsed(itemTitle: string, lineNumber: number) {
+        const key = getOutlineKey(itemTitle, lineNumber);
+        setCollapsedKeys((current) => {
+            const next = new Set(current);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    }
+
     return (
         <section className="space-y-4">
             <SidebarSectionHeader
                 title="Outline"
                 icon={<List size={SIDEBAR_ICON_SIZE} style={{ ...SIDEBAR_ICON_STYLE, color: theme.colors.text.muted, marginRight: "1rem" }} />}
             />
-            <div className="space-y-2 text-[0.75rem]" style={{ color: theme.colors.text.muted, padding: "1rem" }}>
-                <div className="flex items-center gap-2"> Meeting Goals</div>
-                <div className="flex items-center gap-2"> Technical Specs</div>
-                <div className="flex items-center gap-2" style={{ paddingLeft: theme.spacing[2] }}> Backend Refactor</div>
-                <div className="flex items-center gap-2"> Action Items</div>
-            </div>
+            {!activeNote ? (
+                <EmptyState>Select a note to see the outline.</EmptyState>
+            ) : outlineItems.length === 0 ? (
+                <EmptyState>No headers found.</EmptyState>
+            ) : (
+                <div className="space-y-1" style={{ padding: "1rem" }}>
+                    {visibleOutlineItems.map((item) => {
+                        const outlineIndex = outlineItems.findIndex(
+                            (outlineItem) =>
+                                outlineItem.lineNumber === item.lineNumber && outlineItem.title === item.title
+                        );
+                        const canCollapse = hasNestedChildren(outlineItems, outlineIndex);
+                        const isCollapsed = collapsedKeys.has(getOutlineKey(item.title, item.lineNumber));
+
+                        return (
+                            <div
+                                key={`${item.kind}-${item.lineNumber}-${item.title}`}
+                                className="flex items-center gap-1"
+                                style={{ paddingLeft: getOutlineIndent(item.level) }}
+                            >
+                                {canCollapse ? (
+                                    <button
+                                        type="button"
+                                        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${item.title} section`}
+                                        onClick={() => toggleCollapsed(item.title, item.lineNumber)}
+                                        className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-[color:var(--color-background-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]"
+                                        style={{ color: theme.colors.text.muted }}
+                                    >
+                                        {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+                                    </button>
+                                ) : (
+                                    <span className="h-5 w-5 shrink-0" aria-hidden="true" />
+                                )}
+                                <button
+                                    type="button"
+                                    onClick={() => onNavigate(item.lineNumber)}
+                                    className="flex-1 rounded-lg text-left text-[0.75rem] transition-all duration-150 hover:bg-[color:var(--color-background-secondary)] hover:text-[color:var(--color-text-primary)] hover:shadow-sm hover:translate-x-1 focus-visible:bg-[color:var(--color-background-secondary)] focus-visible:text-[color:var(--color-text-primary)] focus-visible:shadow-sm focus-visible:translate-x-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--primary)]"
+                                    style={{
+                                        color: theme.colors.text.muted,
+                                        paddingTop: "0.375rem",
+                                        paddingRight: "0.5rem",
+                                        paddingBottom: "0.375rem",
+                                        paddingLeft: "0.25rem",
+                                    }}
+                                >
+                                    {item.title}
+                                </button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
         </section>
     );
 }
@@ -422,7 +538,13 @@ export function RightSidebar() {
                     onOpen={(path) => app.workspace.openNote(path)}
                 />
                 <TagsSection activeNote={activeNote} tags={allTags} />
-                <OutlineSection />
+                <OutlineSection
+                    activeNote={activeNote}
+                    activeNoteContent={activeNoteContent}
+                    onNavigate={(lineNumber) => {
+                        app.editor.navigateToLine(lineNumber);
+                    }}
+                />
             </div>
         </BaseSidebar>
     );

--- a/src/plugins/api/EditorAPI.ts
+++ b/src/plugins/api/EditorAPI.ts
@@ -1,5 +1,5 @@
 import { Compartment, type Extension } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import type { TessellumApp } from "../TessellumApp";
 
 /**
@@ -18,9 +18,26 @@ export class EditorAPI {
         this.app = app;
     }
 
-    // Called when the EditorView is created/destroyed
-    setView(view: EditorView | null) : void{
+    // Called when the EditorView is created/destroyed.
+    setView(view: EditorView | null): void {
         this.view = view;
+    }
+
+    navigateToLine(lineNumber: number): boolean {
+        if (!this.view) return false;
+        if (!Number.isInteger(lineNumber) || !Number.isFinite(lineNumber)) return false;
+        if (lineNumber < 1 || lineNumber > this.view.state.doc.lines) return false;
+
+        const line = this.view.state.doc.line(lineNumber);
+        this.view.dispatch({
+            selection: { anchor: line.from },
+            effects: EditorView.scrollIntoView(line.from, {
+                y: "start",
+                yMargin: 24,
+            }),
+        });
+        this.view.focus();
+        return true;
     }
 
     /** Returns the initial array of Extensions.
@@ -29,8 +46,8 @@ export class EditorAPI {
      */
     getInitialExtensions(): Extension[] {
         return Array.from(this.compartments.entries()).map(
-            ([id, compartment]) =>
-                compartment.of(this.extensions.get(id) ?? []))
+            ([id, compartment]) => compartment.of(this.extensions.get(id) ?? [])
+        );
     }
 
     /**
@@ -47,23 +64,23 @@ export class EditorAPI {
         this.reconfigure(pluginId);
     }
 
-    // Remove the extensions of a plugin
+    // Remove the extensions of a plugin.
     unregisterExtensions(pluginId: string): void {
         this.extensions.delete(pluginId);
         this.reconfigure(pluginId);
     }
 
-    // Reconfigure the editor with the new extensions
+    // Reconfigure the editor with the new extensions.
     private reconfigure(pluginId: string): void {
         if (!this.view) return;
         const compartment = this.compartments.get(pluginId);
         if (!compartment) return;
         this.view.dispatch({
-            effects: compartment.reconfigure(this.extensions.get(pluginId) || [])
-        })
+            effects: compartment.reconfigure(this.extensions.get(pluginId) || []),
+        });
     }
 
-    // Get the active EditorView
+    // Get the active EditorView.
     getActiveView(): EditorView | null {
         return this.view;
     }

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -159,3 +159,11 @@ useGraphStore.subscribe((state) => {
         selectedGraphNode: state.selectedGraphNode,
     });
 });
+
+useEditorContentStore.subscribe((state) => {
+    useEditorStore.setState({
+        activeNoteContent: state.activeNoteContent,
+        isDirty: state.isDirty,
+        editorFontSizePx: state.editorFontSizePx,
+    });
+});

--- a/src/utils/outline.ts
+++ b/src/utils/outline.ts
@@ -1,0 +1,87 @@
+export type OutlineItemKind = "markdown";
+
+export interface OutlineItem {
+    title: string;
+    level: number;
+    kind: OutlineItemKind;
+    lineNumber: number;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+interface FenceInfo {
+    marker: "`" | "~";
+    length: number;
+}
+
+function normalizeContent(content: string): string {
+    return content.replace(/\r\n?/g, "\n");
+}
+
+function getFenceInfo(line: string): FenceInfo | null {
+    const trimmed = line.trimStart();
+    const match = trimmed.match(/^(`{3,}|~{3,})/);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        marker: match[1][0] as FenceInfo["marker"],
+        length: match[1].length,
+    };
+}
+
+function forEachOutlineLine(lines: string[], visit: (line: string, index: number) => void): void {
+    let activeFence: FenceInfo | null = null;
+
+    for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
+        const fence = getFenceInfo(line);
+        if (fence && !activeFence) {
+            activeFence = fence;
+            continue;
+        }
+
+        if (fence && activeFence && fence.marker === activeFence.marker && fence.length >= activeFence.length) {
+            activeFence = null;
+            continue;
+        }
+
+        if (activeFence) {
+            continue;
+        }
+
+        visit(line, index);
+    }
+}
+
+function parseMarkdownHeadings(lines: string[]): OutlineItem[] {
+    const items: OutlineItem[] = [];
+
+    forEachOutlineLine(lines, (line, index) => {
+        const match = line.match(HEADING_RE);
+        if (!match) {
+            return;
+        }
+
+        const [, hashes, rawTitle] = match;
+        const title = rawTitle.trim();
+        if (!title) {
+            return;
+        }
+
+        items.push({
+            title,
+            level: hashes.length,
+            kind: "markdown",
+            lineNumber: index + 1,
+        });
+    });
+
+    return items;
+}
+
+export function parseOutline(content: string): OutlineItem[] {
+    const normalized = normalizeContent(content);
+    const lines = normalized.split("\n");
+    return parseMarkdownHeadings(lines);
+}


### PR DESCRIPTION
- Introduced `markdownHeadingFoldExtension` to enhance collapsing and expanding of markdown headings with React-powered icons (`lucide-react` ChevronRight) and smoother toggle behavior.
- Enhanced accessibility with ARIA attributes and added support for reduced-motion for animations.
- Updated the Outline panel to include a dynamic heading structure with expandable sections, enabling improved navigation and usability.
- Added a `navigateToLine` method in `EditorAPI` to enable direct line navigation in the editor, integrated into the folding and outline functionality.
- Improved performance with optimized DOM updates during interactions.