### PR TITLE
Source-Mode-US(#34)

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -612,7 +612,7 @@ export function Editor() {
         handleSlashSelectRef.current?.(cmd, view);
     });
 
-    const pluginExtensions = useEditorExtensions();
+    const pluginExtensions = useEditorExtensions(editorMode);
     const { wikiLinkSuggestionsExtension, wikiLinkSuggestionsProps } = useWikiLinkSuggestions(vaultPath || "");
     const {
         handleSlashSelect,

--- a/src/components/Editor/hooks/sourceModeExtensions.ts
+++ b/src/components/Editor/hooks/sourceModeExtensions.ts
@@ -1,0 +1,33 @@
+import type { EditorMode } from "../../../constants/editorModes";
+
+const SOURCE_MODE_HIDDEN_PLUGIN_IDS = new Set([
+    "markdown-preview",
+    "divider",
+    "math",
+    "inline-code",
+    "callout",
+    "table",
+    "wikilink",
+    "code",
+    "mermaid",
+    "frontmatter",
+    "inline-tags",
+    "media-embed",
+    "task-list",
+]);
+
+export function getEditorExtensionPluginIds(editorMode: EditorMode, pluginIds: string[]): string[] {
+    if (editorMode !== "source") {
+        return pluginIds;
+    }
+
+    return pluginIds.filter((pluginId) => !SOURCE_MODE_HIDDEN_PLUGIN_IDS.has(pluginId));
+}
+
+export function getInitialExtensionPluginIds(editorMode: EditorMode, pluginIds: string[]): string[] {
+    return getEditorExtensionPluginIds(editorMode, pluginIds);
+}
+
+export function isSourceModeEnabled(config: { disabled?: boolean }): boolean {
+    return !config.disabled;
+}

--- a/src/components/Editor/hooks/useEditorExtensions.ts
+++ b/src/components/Editor/hooks/useEditorExtensions.ts
@@ -4,6 +4,8 @@ import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { TessellumApp } from "../../../plugins/TessellumApp";
 import { markdownHeadingFoldExtension } from "../extensions/markdown-heading-fold";
+import type { EditorMode } from "../../../constants/editorModes";
+import { getInitialExtensionPluginIds } from "./sourceModeExtensions";
 
 const markdownCloseBracketsExtension = markdownLanguage.data.of({
     closeBrackets: {
@@ -20,15 +22,20 @@ const markdownCloseBracketsExtension = markdownLanguage.data.of({
  * The plugin extensions are wrapped in Compartments by EditorAPI,
  * allowing individual plugins to be reconfigured at runtime.
  */
-export function useEditorExtensions() {
+export function useEditorExtensions(editorMode: EditorMode) {
     return useMemo(() => {
         const app = TessellumApp.instance;
+        const visiblePluginIds = getInitialExtensionPluginIds(
+            editorMode,
+            app.editor.getRegisteredExtensionPluginIds()
+        );
+
         return [
             markdown({ base: markdownLanguage, codeLanguages: languages }),
             markdownCloseBracketsExtension,
             markdownHeadingFoldExtension,
             EditorView.lineWrapping,
-            ...app.editor.getInitialExtensions(),
+            ...app.editor.getInitialExtensionsForPluginIds(visiblePluginIds),
         ];
-    }, []);
+    }, [editorMode]);
 }

--- a/src/constants/editorModes.tsx
+++ b/src/constants/editorModes.tsx
@@ -26,7 +26,6 @@ export const EDITOR_MODES: Record<
         statusLabel: "EDITING",
         editable: true,
         icon: <Code2 size={12} />,
-        disabled: true,
     },
 };
 

--- a/src/plugins/api/EditorAPI.ts
+++ b/src/plugins/api/EditorAPI.ts
@@ -50,6 +50,20 @@ export class EditorAPI {
         );
     }
 
+    getInitialExtensionsForPluginIds(pluginIds: string[]): Extension[] {
+        return pluginIds.flatMap((pluginId) => {
+            const compartment = this.compartments.get(pluginId);
+            if (!compartment) {
+                return [];
+            }
+            return [compartment.of(this.extensions.get(pluginId) ?? [])];
+        });
+    }
+
+    getRegisteredExtensionPluginIds(): string[] {
+        return Array.from(this.compartments.keys());
+    }
+
     /**
      * Registers the extensions for a plugin. Replaces the plugins extension
      * set.


### PR DESCRIPTION
### Description

This pull request introduces support for handling editor-specific extensions using mode-based plugin filtering. Key changes include:

- Enhancing `useEditorExtensions` to accept `editorMode` and apply filtering for plugins specific to the source mode.
- Introducing `getInitialExtensionPluginIds` and helper methods to manage the visibility of plugins based on editor modes.
- Adding `getInitialExtensionsForPluginIds` to `EditorAPI` for on-demand extension compartment management.
- Allowing customization of plugin visibility for source mode by excluding certain plugins dynamically.
- Refactoring extension-related logic for improved code clarity and maintainability.