### PR TITLE
Vim-Keybinds-US(#41)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/language-data": "^6.5.2",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.11",
+        "@replit/codemirror-vim": "^6.3.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.5.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
@@ -2165,6 +2166,19 @@
       "peer": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@replit/codemirror-vim": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz",
+      "integrity": "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/commands": "6.x.x",
+        "@codemirror/language": "6.x.x",
+        "@codemirror/search": "6.x.x",
+        "@codemirror/state": "6.x.x",
+        "@codemirror/view": "6.x.x"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.11",
+    "@replit/codemirror-vim": "^6.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.5.0",
     "@tauri-apps/plugin-fs": "^2.4.5",

--- a/src/components/Editor/hooks/editorExtensionOrder.ts
+++ b/src/components/Editor/hooks/editorExtensionOrder.ts
@@ -1,0 +1,24 @@
+import type { Extension } from "@codemirror/state";
+
+interface BuildEditorExtensionOrderOptions {
+    baseExtensions: Extension[];
+    pluginExtensions: Extension[];
+    vimMode: boolean;
+    vimExtension: Extension;
+}
+
+export function buildEditorExtensionOrder({
+                                              baseExtensions,
+                                              pluginExtensions,
+                                              vimMode,
+                                              vimExtension,
+                                          }: BuildEditorExtensionOrderOptions): Extension[] {
+    const extensions = [...baseExtensions];
+
+    if (vimMode) {
+        extensions.push(vimExtension);
+    }
+
+    extensions.push(...pluginExtensions);
+    return extensions;
+}

--- a/src/components/Editor/hooks/editorExtensionsBuilder.ts
+++ b/src/components/Editor/hooks/editorExtensionsBuilder.ts
@@ -1,0 +1,39 @@
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { languages } from "@codemirror/language-data";
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { vim } from "@replit/codemirror-vim";
+import { markdownHeadingFoldExtension } from "../extensions/markdown-heading-fold.ts";
+import { buildEditorExtensionOrder } from "./editorExtensionOrder.ts";
+
+const markdownCloseBracketsExtension = markdownLanguage.data.of({
+    closeBrackets: {
+        // Reuse CodeMirror's native bracket behavior for markdown markers too.
+        brackets: ["(", "[", "{", "'", "\"", "`", "*", "$", "~"],
+    },
+});
+interface BuildEditorExtensionsOptions {
+    pluginExtensions: Extension[];
+    vimMode: boolean;
+    vimExtension?: Extension;
+}
+
+export function buildEditorExtensions({
+                                          pluginExtensions,
+                                          vimMode,
+                                          vimExtension = vim(),
+                                      }: BuildEditorExtensionsOptions): Extension[] {
+    const baseExtensions: Extension[] = [
+        markdown({ base: markdownLanguage, codeLanguages: languages }),
+        markdownCloseBracketsExtension,
+        markdownHeadingFoldExtension,
+        EditorView.lineWrapping,
+    ];
+
+    return buildEditorExtensionOrder({
+        baseExtensions,
+        pluginExtensions,
+        vimMode,
+        vimExtension,
+    });
+}

--- a/src/components/Editor/hooks/editorExtensionsBuilder.ts
+++ b/src/components/Editor/hooks/editorExtensionsBuilder.ts
@@ -19,10 +19,10 @@ interface BuildEditorExtensionsOptions {
 }
 
 export function buildEditorExtensions({
-                                          pluginExtensions,
-                                          vimMode,
-                                          vimExtension = vim(),
-                                      }: BuildEditorExtensionsOptions): Extension[] {
+      pluginExtensions,
+      vimMode,
+      vimExtension = vim(),
+  }: BuildEditorExtensionsOptions): Extension[] {
     const baseExtensions: Extension[] = [
         markdown({ base: markdownLanguage, codeLanguages: languages }),
         markdownCloseBracketsExtension,

--- a/src/components/Editor/hooks/useEditorExtensions.ts
+++ b/src/components/Editor/hooks/useEditorExtensions.ts
@@ -1,18 +1,9 @@
 import { useMemo } from "react";
-import { EditorView } from "@codemirror/view";
-import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { languages } from "@codemirror/language-data";
 import { TessellumApp } from "../../../plugins/TessellumApp";
-import { markdownHeadingFoldExtension } from "../extensions/markdown-heading-fold";
 import type { EditorMode } from "../../../constants/editorModes";
 import { getInitialExtensionPluginIds } from "./sourceModeExtensions";
-
-const markdownCloseBracketsExtension = markdownLanguage.data.of({
-    closeBrackets: {
-        // Reuse CodeMirror's native bracket behavior for markdown markers too.
-        brackets: ["(", "[", "{", "'", "\"", "`", "*", "$", "~"],
-    },
-});
+import { useSettingsStore } from "../../../stores";
+import { buildEditorExtensions } from "./editorExtensionsBuilder.ts";
 
 /**
  * Assembles the full CodeMirror extension array by combining:
@@ -23,6 +14,8 @@ const markdownCloseBracketsExtension = markdownLanguage.data.of({
  * allowing individual plugins to be reconfigured at runtime.
  */
 export function useEditorExtensions(editorMode: EditorMode) {
+    const vimMode = useSettingsStore((state) => state.vimMode);
+
     return useMemo(() => {
         const app = TessellumApp.instance;
         const visiblePluginIds = getInitialExtensionPluginIds(
@@ -30,12 +23,9 @@ export function useEditorExtensions(editorMode: EditorMode) {
             app.editor.getRegisteredExtensionPluginIds()
         );
 
-        return [
-            markdown({ base: markdownLanguage, codeLanguages: languages }),
-            markdownCloseBracketsExtension,
-            markdownHeadingFoldExtension,
-            EditorView.lineWrapping,
-            ...app.editor.getInitialExtensionsForPluginIds(visiblePluginIds),
-        ];
-    }, [editorMode]);
+        return buildEditorExtensions({
+            pluginExtensions: app.editor.getInitialExtensionsForPluginIds(visiblePluginIds),
+            vimMode,
+        });
+    }, [editorMode, vimMode]);
 }

--- a/src/components/Settings/EditorSettings.tsx
+++ b/src/components/Settings/EditorSettings.tsx
@@ -16,6 +16,8 @@ export function EditorSettings() {
     const setEditorLineHeight = useSettingsStore((state) => state.setEditorLineHeight);
     const editorLetterSpacing = useSettingsStore((state) => state.editorLetterSpacing);
     const setEditorLetterSpacing = useSettingsStore((state) => state.setEditorLetterSpacing);
+    const vimMode = useSettingsStore((state) => state.vimMode);
+    const setVimMode = useSettingsStore((state) => state.setVimMode);
 
     const [lineNumbers, setLineNumbers] = useState(false);
 
@@ -106,8 +108,8 @@ export function EditorSettings() {
                 <ToggleSetting
                     label={t("editor.vimMode")}
                     description={t("editor.vimModeDescription")}
-                    checked={false}
-                    onChange={() => { }}
+                    checked={vimMode}
+                    onChange={setVimMode}
                 />
             </SettingSection>
         </div>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -5,11 +5,13 @@ const FONT_FAMILY_KEY = "tessellum:fontFamily";
 const EDITOR_LINE_HEIGHT_KEY = "tessellum:editorLineHeight";
 const EDITOR_LETTER_SPACING_KEY = "tessellum:editorLetterSpacing";
 const LOCALE_KEY = "tessellum:locale";
+const VIM_MODE_KEY = "tessellum:vimMode";
 
 const DEFAULT_FONT_FAMILY = "Geist Sans";
 const DEFAULT_EDITOR_LINE_HEIGHT = 1.7;
 const DEFAULT_EDITOR_LETTER_SPACING = 0;
 export const DEFAULT_LOCALE: AppLocale = "en";
+export const DEFAULT_VIM_MODE = false;
 
 function readString(key: string, fallback: string): string {
     const raw = localStorage.getItem(key);
@@ -24,6 +26,13 @@ function readNumber(key: string, fallback: number): number {
     return parsed;
 }
 
+function readBoolean(key: string, fallback: boolean): boolean {
+    const raw = localStorage.getItem(key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return fallback;
+}
+
 export function readStoredLocale(): AppLocale {
     const raw = localStorage.getItem(LOCALE_KEY);
     if (raw && isSupportedLocale(raw)) {
@@ -32,11 +41,16 @@ export function readStoredLocale(): AppLocale {
     return DEFAULT_LOCALE;
 }
 
+export function readStoredVimMode(): boolean {
+    return readBoolean(VIM_MODE_KEY, DEFAULT_VIM_MODE);
+}
+
 export interface SettingsState {
     fontFamily: string;
     editorLineHeight: number;
     editorLetterSpacing: number;
     locale: AppLocale;
+    vimMode: boolean;
 }
 
 export interface SettingsActions {
@@ -44,6 +58,7 @@ export interface SettingsActions {
     setEditorLineHeight: (value: number) => void;
     setEditorLetterSpacing: (value: number) => void;
     setLocale: (value: AppLocale) => void;
+    setVimMode: (value: boolean) => void;
 }
 
 export type SettingsStore = SettingsState & SettingsActions;
@@ -53,6 +68,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     editorLineHeight: readNumber(EDITOR_LINE_HEIGHT_KEY, DEFAULT_EDITOR_LINE_HEIGHT),
     editorLetterSpacing: readNumber(EDITOR_LETTER_SPACING_KEY, DEFAULT_EDITOR_LETTER_SPACING),
     locale: readStoredLocale(),
+    vimMode: readStoredVimMode(),
 
     setFontFamily: (fontFamily) => set(() => {
         localStorage.setItem(FONT_FAMILY_KEY, fontFamily);
@@ -69,5 +85,9 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     setLocale: (locale) => set(() => {
         localStorage.setItem(LOCALE_KEY, locale);
         return { locale };
+    }),
+    setVimMode: (vimMode) => set(() => {
+        localStorage.setItem(VIM_MODE_KEY, String(vimMode));
+        return { vimMode };
     }),
 }));


### PR DESCRIPTION
## Changes in this pull request

- Integrated `@replit/codemirror-vim` package for enabling Vim mode.
- Added a `vimMode` property to editor settings and persistent storage.
- Implemented UI controls for toggling Vim mode within `EditorSettings`.
- Updated the editor extension builder system to accommodate Vim mode functionality.
- Adjusted the indentation of function parameters in the `buildEditorExtensions` method for readability.