### PR TITLE
Add selection toolbar and keyboard shortcut improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,6 +165,12 @@ function App() {
                 return;
             }
 
+                if (modifier && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "g") {
+                event.preventDefault();
+                setViewMode(viewMode === "graph" ? "editor" : "graph");
+                return;
+            }
+
             if (modifier && event.key.toLowerCase() === "v") {
                 if (!clipboardFilePaste.shouldHandleShortcutPaste(target)) {
                     return;
@@ -213,7 +219,7 @@ function App() {
 
         window.addEventListener("keydown", onKeyDown);
         return () => window.removeEventListener("keydown", onKeyDown);
-    }, [activeNote, clipboardFileCopy, clipboardFilePaste, closeTab, app, files, selectedFilePaths, toggleSidebar]);
+    }, [activeNote, clipboardFileCopy, clipboardFilePaste, closeTab, app, files, selectedFilePaths, setViewMode, toggleSidebar, viewMode]);
 
     useEffect(() => {
         const ref = app.events.on("ui:open-command-palette", () => {

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -37,8 +37,10 @@ import { useAccessibilityStore } from "../../stores";
 import { WorkspaceOverview } from "./workspaceOverview/WorkspaceOverview";
 import type { HeroProjection, WorkspaceCardItem } from "./workspaceOverview/types";
 import { useAppTranslation } from "../../i18n/react.tsx";
+import { SelectionToolbar } from "./toolbar/SelectionToolbar";
 import {
     applyMarkdownShortcut,
+    getMarkdownMarker,
     matchesMarkdownShortcut,
     matchesTabNavigationShortcut,
 } from "./utils/markdownShortcuts.ts";
@@ -474,6 +476,7 @@ const dividerStyle: CSSProperties = {
 function EditorBody({
                         editorRef,
                         activeNotePath,
+                        selectionToolbarEnabled,
                         editorFontSizePx,
                         content,
                         editorExtensions,
@@ -494,6 +497,7 @@ function EditorBody({
                     }: {
     editorRef: RefObject<ReactCodeMirrorRef>;
     activeNotePath: string;
+    selectionToolbarEnabled: boolean;
     editorFontSizePx: number;
     content: string;
     editorExtensions: Extension[];
@@ -537,6 +541,11 @@ function EditorBody({
                         highlightActiveLine: false,
                         highlightActiveLineGutter: false,
                     }}
+                />
+
+                <SelectionToolbar
+                    editorRef={editorRef}
+                    enabled={selectionToolbarEnabled}
                 />
 
                 <SlashMenu
@@ -765,6 +774,7 @@ export function Editor() {
 
     const titleFontSizePx = useMemo(() => Math.round(28 * editorFontSizePx / 16), [editorFontSizePx]);
     const isEditable = EDITOR_MODES[editorMode].editable;
+    const selectionToolbarEnabled = isEditable && (editorMode === "live-preview" || editorMode === "source");
     const editableExtension = useMemo(() => EditorView.editable.of(isEditable), [isEditable]);
     const previewForceHideExtension = useMemo(
         () => markdownPreviewForceHideFacet.of(!isEditable),
@@ -824,13 +834,13 @@ export function Editor() {
 
             if (matchesMarkdownShortcut(event, "bold")) {
                 event.preventDefault();
-                applyMarkdownShortcut(editorRef.current?.view, "**");
+                applyMarkdownShortcut(editorRef.current?.view, getMarkdownMarker("bold"));
                 return;
             }
 
             if (matchesMarkdownShortcut(event, "italic")) {
                 event.preventDefault();
-                applyMarkdownShortcut(editorRef.current?.view, "*");
+                applyMarkdownShortcut(editorRef.current?.view, getMarkdownMarker("italic"));
                 return;
             }
 
@@ -964,6 +974,7 @@ export function Editor() {
             <EditorBody
                 editorRef={editorRef}
                 activeNotePath={activeNote.path}
+                selectionToolbarEnabled={selectionToolbarEnabled}
                 content={content}
                 editorExtensions={editorExtensions}
                 handleContentChange={handleContentChangeGuarded}

--- a/src/components/Editor/toolbar/SelectionToolbar.tsx
+++ b/src/components/Editor/toolbar/SelectionToolbar.tsx
@@ -13,10 +13,12 @@ import {
     type ListType,
 } from "../utils/markdownShortcuts";
 import { useSelectionToolbar } from "./useSelectionToolbar";
+import {cn} from "../../../lib/utils.ts";
 
 type SelectionToolbarProps = {
     editorRef: RefObject<ReactCodeMirrorRef>;
     enabled: boolean;
+    placement?: "top" | "bottom";
 };
 
 const ACTION_TEXT_STYLE: Record<MarkdownAction, CSSProperties> = {
@@ -45,7 +47,7 @@ function ListDropdown({
                       }: {
     onSelect: (listType: ListType) => void;
     t: (key: string) => string;
-}) {
+}, placement = "bottom",) {
     const [isOpen, setIsOpen] = useState(false);
 
     const options: { type: ListType; icon: React.ReactNode; label: string }[] = [
@@ -55,7 +57,9 @@ function ListDropdown({
     ];
 
     return (
-        <div className="relative flex items-center h-8" style={{ fontFamily: theme.typography.fontFamily.sans }}>
+        <div className={cn("relative flex items-center h-8", placement === 'top'
+            ? "-translate-y-full mb-2 origin-bottom"
+            : "mt-2 origin-top")} style={{ fontFamily: theme.typography.fontFamily.sans }}>
             {/* Primary Action Button (Bulleted List) */}
             <button
                 type="button"

--- a/src/components/Editor/toolbar/SelectionToolbar.tsx
+++ b/src/components/Editor/toolbar/SelectionToolbar.tsx
@@ -1,0 +1,224 @@
+import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import type { CSSProperties, RefObject } from "react";
+import { useRef, useState } from "react";
+import { List, ListOrdered, CheckSquare, ChevronDown } from "lucide-react";
+import { theme } from "../../../styles/theme";
+import { useAppTranslation } from "../../../i18n/react";
+import {
+    getInlineMarkdownActions,
+    getMarkdownMarker,
+    applyMarkdownShortcut,
+    applyListFormatting,
+    type MarkdownAction,
+    type ListType,
+} from "../utils/markdownShortcuts";
+import { useSelectionToolbar } from "./useSelectionToolbar";
+
+type SelectionToolbarProps = {
+    editorRef: RefObject<ReactCodeMirrorRef>;
+    enabled: boolean;
+};
+
+const ACTION_TEXT_STYLE: Record<MarkdownAction, CSSProperties> = {
+    bold: { fontWeight: Number(theme.typography.fontWeight.bold) },
+    italic: { fontStyle: "italic" },
+    strikethrough: { textDecoration: "line-through" },
+};
+
+const ACTION_LABEL_KEYS: Record<MarkdownAction, string> = {
+    bold: "editor.selectionToolbar.bold",
+    italic: "editor.selectionToolbar.italic",
+    strikethrough: "editor.selectionToolbar.strikethrough",
+};
+
+function getActionButtonLabel(action: MarkdownAction): string {
+    if (action === "strikethrough") {
+        return "S";
+    }
+
+    return action === "bold" ? "B" : "I";
+}
+
+function ListDropdown({
+                          onSelect,
+                          t,
+                      }: {
+    onSelect: (listType: ListType) => void;
+    t: (key: string) => string;
+}) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const options: { type: ListType; icon: React.ReactNode; label: string }[] = [
+        { type: "bulleted", icon: <List size={14} />, label: t("editor.selectionToolbar.bulletedList") },
+        { type: "numbered", icon: <ListOrdered size={14} />, label: t("editor.selectionToolbar.numberedList") },
+        { type: "todo", icon: <CheckSquare size={14} />, label: t("editor.selectionToolbar.todoList") },
+    ];
+
+    return (
+        <div className="relative flex items-center h-8" style={{ fontFamily: theme.typography.fontFamily.sans }}>
+            {/* Primary Action Button (Bulleted List) */}
+            <button
+                type="button"
+                aria-label={options[0].label}
+                title={options[0].label}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onSelect("bulleted")}
+                className="flex items-center justify-center h-8 w-8 rounded-l-md border-none transition-colors hover:bg-black/5"
+                style={{
+                    color: theme.colors.text.primary,
+                    backgroundColor: "transparent",
+                    cursor: "pointer",
+                }}
+            >
+                <List size={16} />
+            </button>
+
+            {/* Dropdown Trigger */}
+            <button
+                type="button"
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex items-center justify-center h-8 w-4 rounded-r-md border-none transition-colors hover:bg-black/5"
+                style={{
+                    color: theme.colors.text.secondary,
+                    backgroundColor: "transparent",
+                    cursor: "pointer",
+                    borderLeft: `1px solid ${theme.colors.border.light}`,
+                }}
+            >
+                <ChevronDown size={12} />
+            </button>
+
+            {/* Dropdown Menu */}
+            {isOpen && (
+                <>
+                    <div
+                        className="fixed inset-0 z-40"
+                        onMouseDown={(e) => {
+                            setIsOpen(false);
+                            e.preventDefault();
+                        }}
+                    />
+                    <div
+                        className="absolute bottom-full mb-1 left-0 flex flex-col overflow-hidden rounded-md border min-w-[160px] z-50 py-1"
+                        style={{
+                            backgroundColor: theme.colors.background.secondary,
+                            borderColor: theme.colors.border.light,
+                            boxShadow: theme.shadows.md,
+                        }}
+                    >
+                        {options.map((option) => (
+                            <button
+                                key={option.type}
+                                type="button"
+                                onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    setIsOpen(false);
+                                    onSelect(option.type);
+                                }}
+                                className="flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-black/5 w-full text-left"
+                                style={{
+                                    color: theme.colors.text.primary,
+                                    backgroundColor: "transparent",
+                                    border: "none",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                <span style={{ color: theme.colors.text.secondary }}>{option.icon}</span>
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+export function SelectionToolbar({ editorRef, enabled }: SelectionToolbarProps) {
+    const { t } = useAppTranslation("core");
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const { isOpen, x, y, placement, refresh } = useSelectionToolbar({
+        editorRef,
+        toolbarRef,
+        enabled,
+    });
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const handleAction = (action: MarkdownAction) => {
+        const view = editorRef.current?.view;
+        if (!view) {
+            return;
+        }
+
+        applyMarkdownShortcut(view, getMarkdownMarker(action));
+        view.focus();
+        requestAnimationFrame(refresh);
+    };
+
+    return (
+        <div
+            ref={toolbarRef}
+            role="toolbar"
+            aria-label={t("editor.selectionToolbar.label")}
+            className="flex items-center gap-1 px-2 py-1.5"
+            style={{
+                position: "absolute",
+                left: x,
+                top: y,
+                transform: `translate(-50%, ${placement === 'top' ? '-100%' : '0'})`,
+                zIndex: 50,
+                borderRadius: theme.borderRadius.lg,
+                backgroundColor: theme.colors.background.secondary,
+                border: `1px solid ${theme.colors.border.light}`,
+                boxShadow: theme.shadows.lg,
+            }}
+        >
+            {getInlineMarkdownActions().map((action) => {
+                const actionLabel = t(ACTION_LABEL_KEYS[action.id]);
+
+                return (
+                    <button
+                        key={action.id}
+                        type="button"
+                        aria-label={actionLabel}
+                        title={actionLabel}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => handleAction(action.id)}
+                        className="h-8 w-8 rounded-md border-none text-sm transition-colors"
+                        style={{
+                            color: theme.colors.text.primary,
+                            backgroundColor: "transparent",
+                            cursor: "pointer",
+                            fontFamily: theme.typography.fontFamily.sans,
+                            ...ACTION_TEXT_STYLE[action.id],
+                        }}
+                    >
+                        {getActionButtonLabel(action.id)}
+                    </button>
+                );
+            })}
+
+            <div
+                className="h-5 w-px mx-1"
+                style={{ backgroundColor: theme.colors.border.light }}
+            />
+
+            <ListDropdown
+                t={t}
+                onSelect={(listType) => {
+                    const view = editorRef.current?.view;
+                    if (!view) return;
+                    applyListFormatting(view, listType);
+                    view.focus();
+                    requestAnimationFrame(refresh);
+                }}
+            />
+        </div>
+    );
+}

--- a/src/components/Editor/toolbar/useSelectionToolbar.ts
+++ b/src/components/Editor/toolbar/useSelectionToolbar.ts
@@ -1,0 +1,148 @@
+import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import { RefObject, useCallback, useEffect, useMemo, useState } from "react";
+
+type SelectionToolbarState = {
+    isOpen: boolean;
+    x: number;
+    y: number;
+    placement: 'top' | 'bottom';
+};
+
+type UseSelectionToolbarOptions = {
+    editorRef: RefObject<ReactCodeMirrorRef>;
+    toolbarRef: RefObject<HTMLDivElement>;
+    enabled: boolean;
+};
+
+const HIDDEN_TOOLBAR_STATE: SelectionToolbarState = {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    placement: 'top',
+};
+
+const TOOLBAR_MIN_VIEWPORT_PADDING_PX = 12;
+const TOOLBAR_VERTICAL_OFFSET_PX = 10;
+const TOOLBAR_FALLBACK_WIDTH_PX = 164;
+
+function getSelectionToolbarState({
+                                      editorRef,
+                                      toolbarRef,
+                                      enabled,
+                                  }: UseSelectionToolbarOptions): SelectionToolbarState {
+    if (!enabled) {
+        return HIDDEN_TOOLBAR_STATE;
+    }
+
+    const view = editorRef.current?.view;
+    if (!view) {
+        return HIDDEN_TOOLBAR_STATE;
+    }
+
+    const selection = view.state.selection.main;
+    if (selection.empty) {
+        return HIDDEN_TOOLBAR_STATE;
+    }
+
+    const selectionStart = view.coordsAtPos(selection.from);
+    const selectionEnd = view.coordsAtPos(Math.max(selection.from, selection.to - 1));
+
+    if (!selectionStart || !selectionEnd) {
+        return HIDDEN_TOOLBAR_STATE;
+    }
+
+    const editorRect = view.dom.getBoundingClientRect();
+
+    const toolbarWidth = toolbarRef.current?.offsetWidth ?? TOOLBAR_FALLBACK_WIDTH_PX;
+    const selectionLeft = Math.min(selectionStart.left, selectionEnd.left);
+    const selectionRight = Math.max(selectionStart.right, selectionEnd.right);
+    const selectionMidpoint = (selectionLeft + selectionRight) / 2;
+    const minX = editorRect.left + TOOLBAR_MIN_VIEWPORT_PADDING_PX + toolbarWidth / 2;
+    const maxX = editorRect.right - TOOLBAR_MIN_VIEWPORT_PADDING_PX - toolbarWidth / 2;
+    const viewportX = minX > maxX
+        ? (editorRect.left + editorRect.right) / 2
+        : Math.min(Math.max(selectionMidpoint, minX), maxX);
+
+    const x = viewportX - editorRect.left;
+
+    const spaceAbove = selectionStart.top;
+    const TOOLBAR_APPROX_HEIGHT = 44;
+    const placement: 'top' | 'bottom' = spaceAbove < (TOOLBAR_APPROX_HEIGHT + TOOLBAR_MIN_VIEWPORT_PADDING_PX + TOOLBAR_VERTICAL_OFFSET_PX)
+        ? 'bottom'
+        : 'top';
+
+    const viewportY = placement === 'top'
+        ? Math.max(TOOLBAR_MIN_VIEWPORT_PADDING_PX, selectionStart.top - TOOLBAR_VERTICAL_OFFSET_PX)
+        : Math.min(window.innerHeight - TOOLBAR_MIN_VIEWPORT_PADDING_PX, selectionEnd.bottom + TOOLBAR_VERTICAL_OFFSET_PX);
+
+    const y = viewportY - editorRect.top;
+
+    return {
+        isOpen: true,
+        x,
+        y,
+        placement,
+    };
+}
+
+/**
+ * Derives floating toolbar visibility from the active CodeMirror selection.
+ * The hook stays defensive and hides the toolbar whenever selection geometry
+ * is incomplete, which prevents stale overlays from lingering on screen.
+ */
+export function useSelectionToolbar({ editorRef, toolbarRef, enabled }: UseSelectionToolbarOptions) {
+    const [state, setState] = useState<SelectionToolbarState>(HIDDEN_TOOLBAR_STATE);
+
+    const updateToolbar = useCallback(() => {
+        const nextState = getSelectionToolbarState({ editorRef, toolbarRef, enabled });
+        setState((prevState) => {
+            if (
+                prevState.isOpen === nextState.isOpen &&
+                prevState.x === nextState.x &&
+                prevState.y === nextState.y &&
+                prevState.placement === nextState.placement
+            ) {
+                return prevState;
+            }
+            return nextState;
+        });
+    }, [editorRef, toolbarRef, enabled]);
+
+    const view = editorRef.current?.view;
+    const updateEvents = useMemo(
+        () => ["selectionchange", "resize", "scroll"] as const,
+        []
+    );
+
+    useEffect(() => {
+        updateToolbar();
+    }, [updateToolbar, view, enabled]);
+
+    useEffect(() => {
+        if (!enabled) {
+            setState((prevState) => {
+                if (!prevState.isOpen) return prevState;
+                return HIDDEN_TOOLBAR_STATE;
+            });
+            return;
+        }
+
+        const handleSelectionChange = () => updateToolbar();
+        const handleViewportChange = () => updateToolbar();
+
+        document.addEventListener(updateEvents[0], handleSelectionChange);
+        window.addEventListener(updateEvents[1], handleViewportChange);
+        window.addEventListener(updateEvents[2], handleViewportChange, true);
+
+        return () => {
+            document.removeEventListener(updateEvents[0], handleSelectionChange);
+            window.removeEventListener(updateEvents[1], handleViewportChange);
+            window.removeEventListener(updateEvents[2], handleViewportChange, true);
+        };
+    }, [enabled, updateEvents, updateToolbar]);
+
+    return {
+        ...state,
+        refresh: updateToolbar,
+    };
+}

--- a/src/components/Editor/toolbar/useSelectionToolbar.ts
+++ b/src/components/Editor/toolbar/useSelectionToolbar.ts
@@ -24,6 +24,7 @@ const HIDDEN_TOOLBAR_STATE: SelectionToolbarState = {
 const TOOLBAR_MIN_VIEWPORT_PADDING_PX = 12;
 const TOOLBAR_VERTICAL_OFFSET_PX = 10;
 const TOOLBAR_FALLBACK_WIDTH_PX = 164;
+const TOOLBAR_FALLBACK_HEIGHT_PX = 44;
 
 function getSelectionToolbarState({
                                       editorRef,
@@ -65,17 +66,30 @@ function getSelectionToolbarState({
 
     const x = viewportX - editorRect.left;
 
-    const spaceAbove = selectionStart.top;
-    const TOOLBAR_APPROX_HEIGHT = 44;
-    const placement: 'top' | 'bottom' = spaceAbove < (TOOLBAR_APPROX_HEIGHT + TOOLBAR_MIN_VIEWPORT_PADDING_PX + TOOLBAR_VERTICAL_OFFSET_PX)
-        ? 'bottom'
-        : 'top';
+    const toolbarHeight = toolbarRef.current?.offsetHeight ?? TOOLBAR_FALLBACK_HEIGHT_PX;
+    const requiredClearance = toolbarHeight + TOOLBAR_MIN_VIEWPORT_PADDING_PX + TOOLBAR_VERTICAL_OFFSET_PX;
+    const spaceAbove = selectionStart.top - editorRect.top;
+    const spaceBelow = editorRect.bottom - selectionEnd.bottom;
 
-    const viewportY = placement === 'top'
-        ? Math.max(TOOLBAR_MIN_VIEWPORT_PADDING_PX, selectionStart.top - TOOLBAR_VERTICAL_OFFSET_PX)
-        : Math.min(window.innerHeight - TOOLBAR_MIN_VIEWPORT_PADDING_PX, selectionEnd.bottom + TOOLBAR_VERTICAL_OFFSET_PX);
+    const placement: 'top' | 'bottom' = spaceAbove >= requiredClearance
+        ? 'top'
+        : spaceBelow >= requiredClearance || spaceBelow >= spaceAbove
+            ? 'bottom'
+            : 'top';
 
-    const y = viewportY - editorRect.top;
+    const editorHeight = editorRect.height;
+    const minBottomAnchorY = toolbarHeight + TOOLBAR_MIN_VIEWPORT_PADDING_PX;
+    const maxTopAnchorY = Math.max(minBottomAnchorY, editorHeight - TOOLBAR_MIN_VIEWPORT_PADDING_PX);
+    const minTopAnchorY = TOOLBAR_MIN_VIEWPORT_PADDING_PX;
+    const maxTopPlacementY = Math.max(minTopAnchorY, editorHeight - toolbarHeight - TOOLBAR_MIN_VIEWPORT_PADDING_PX);
+
+    const unclampedY = placement === 'top'
+        ? spaceAbove - TOOLBAR_VERTICAL_OFFSET_PX
+        : spaceAbove + (selectionEnd.bottom - selectionStart.top) + TOOLBAR_VERTICAL_OFFSET_PX;
+
+    const y = placement === 'top'
+        ? Math.min(Math.max(unclampedY, minBottomAnchorY), maxTopAnchorY)
+        : Math.min(Math.max(unclampedY, minTopAnchorY), maxTopPlacementY);
 
     return {
         isOpen: true,

--- a/src/components/Editor/utils/markdownShortcuts.ts
+++ b/src/components/Editor/utils/markdownShortcuts.ts
@@ -1,5 +1,13 @@
 import type { EditorView } from "@codemirror/view";
 
+export type MarkdownAction = "bold" | "italic" | "strikethrough";
+export type ListType = "bulleted" | "numbered" | "todo";
+
+export type InlineMarkdownAction = {
+    id: MarkdownAction;
+    label: string;
+};
+
 export type TextSelectionRange = {
     from: number;
     to: number;
@@ -13,7 +21,27 @@ export type TextSelectionResult = {
     };
 };
 
+const MARKDOWN_MARKERS: Record<MarkdownAction, string> = {
+    bold: "**",
+    italic: "*",
+    strikethrough: "~~",
+};
+
+const INLINE_MARKDOWN_ACTIONS: InlineMarkdownAction[] = [
+    { id: "bold", label: "Bold" },
+    { id: "italic", label: "Italic" },
+    { id: "strikethrough", label: "Strike" },
+];
+
 type ShortcutKeyEvent = Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "shiftKey" | "altKey">;
+
+export function getMarkdownMarker(action: MarkdownAction): string {
+    return MARKDOWN_MARKERS[action];
+}
+
+export function getInlineMarkdownActions(): InlineMarkdownAction[] {
+    return INLINE_MARKDOWN_ACTIONS;
+}
 
 export function toggleMarkdownWrap(
     text: string,
@@ -106,5 +134,65 @@ export function applyMarkdownShortcut(view: EditorView | null | undefined, marke
         },
     });
 
+    return true;
+}
+
+export function applyListFormatting(view: EditorView | null | undefined, listType: ListType): boolean {
+    if (!view) {
+        return false;
+    }
+
+    const { state } = view;
+    const selection = state.selection.main;
+    const fromLine = state.doc.lineAt(selection.from);
+    const toLine = state.doc.lineAt(selection.to);
+
+    const changes = [];
+    let allHavePrefix = true;
+
+    const getPrefixRegex = (type: ListType) => {
+        if (type === "bulleted") return /^[-*]\s/;
+        if (type === "numbered") return /^\d+\.\s/;
+        if (type === "todo") return /^- \[(?: |x)\]\s/i;
+        return /^$/;
+    };
+    const anyListRegex = /^([-*]\s|\d+\.\s|- \[(?: |x)\]\s)/i;
+    const targetRegex = getPrefixRegex(listType);
+
+    for (let i = fromLine.number; i <= toLine.number; i++) {
+        const line = state.doc.line(i);
+        if (!targetRegex.test(line.text) && line.text.trim().length > 0) {
+            allHavePrefix = false;
+            break;
+        }
+    }
+
+    let itemNumber = 1;
+    for (let i = fromLine.number; i <= toLine.number; i++) {
+        const line = state.doc.line(i);
+        if (line.text.trim().length === 0 && fromLine.number !== toLine.number) continue;
+
+        const match = line.text.match(anyListRegex);
+        const currentPrefix = match ? match[0] : "";
+        const replaceFrom = line.from;
+        const replaceTo = line.from + currentPrefix.length;
+
+        if (allHavePrefix) {
+            changes.push({ from: replaceFrom, to: replaceTo, insert: "" });
+        } else {
+            let newPrefix = "";
+            if (listType === "bulleted") {
+                newPrefix = "- ";
+            } else if (listType === "numbered") {
+                newPrefix = `${itemNumber}. `;
+                itemNumber++;
+            } else if (listType === "todo") {
+                newPrefix = "- [ ] ";
+            }
+            changes.push({ from: replaceFrom, to: replaceTo, insert: newPrefix });
+        }
+    }
+
+    view.dispatch({ changes });
     return true;
 }

--- a/src/i18n/locales/en/core.ts
+++ b/src/i18n/locales/en/core.ts
@@ -30,6 +30,15 @@ const core = {
         untitled: "Untitled",
         edited: "Edited {{value}}",
         loadingNote: "Loading note...",
+        selectionToolbar: {
+            label: "Selected text formatting",
+            bold: "Bold",
+            italic: "Italic",
+            strikethrough: "Strikethrough",
+            bulletedList: "Bulleted list",
+            numberedList: "Numbered list",
+            todoList: "Todo list",
+        },
     },
     sidebar: {
         emptyTitle: "No notes yet",

--- a/src/i18n/locales/es/core.ts
+++ b/src/i18n/locales/es/core.ts
@@ -30,6 +30,15 @@ const core = {
         untitled: "Sin título",
         edited: "Editado {{value}}",
         loadingNote: "Cargando nota...",
+        selectionToolbar: {
+            label: "Formato del texto seleccionado",
+            bold: "Negrita",
+            italic: "Cursiva",
+            strikethrough: "Tachado",
+            bulletedList: "Lista de viñetas",
+            numberedList: "Lista numerada",
+            todoList: "Lista de tareas",
+        },
     },
     sidebar: {
         emptyTitle: "Todavía no hay notas",


### PR DESCRIPTION
- **Keyboard Shortcut Update**:
  - Introduced a new shortcut `Cmd/Ctrl + G` (no Shift/Alt required) for toggling between graph and editor views.
  - Updated dependencies of event listeners for improved functionality.

- **Selection Toolbar Enhancements**:
  - Improved placement logic and styling for the selection toolbar with dynamic viewport calculations and flexible alignment.
  - Added a `placement` prop to `SelectionToolbar` for user-defined alignment options.
  - Refined styles with updates to class names reflecting the toolbar's placement.

- **Markdown Editor Toolbar**:
  - Implemented a floating toolbar for text formatting options (`bold`, `italic`, `strikethrough`) and list formatting (`bulleted`, `numbered`, `todo`).
  - Synchronized toolbar visibility with text selection state and editor mode (`live-preview` or `source`).
  - Localized toolbar tooltips and labels for `en` and `es`.
  - Refactored markdown formatting utilities for better reusability.