### PR TITLE
Spell-Check-US(#44)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -24,5 +24,5 @@ pub use notes::{
 };
 pub use templates::{create_note_from_template, list_templates};
 pub use vault::{list_files, list_files_tree, move_items, rename_file, set_vault_path};
-pub use watcher::watch_vault;
+pub use watcher::{watch_vault, unwatch_vault};
 pub use search::{search_full_text, search_tags, rebuild_search_index};

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -22,13 +22,11 @@ pub async fn watch_vault(
     handle: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), TessellumError> {
-    // Initialize the watcher
+    // Initialize or replace the watcher so vault switching and dev reloads
+    // do not keep stale watchers alive.
     let mut watcher_guard = state.watcher.lock().await;
-    
-    if watcher_guard.is_some() {
-        return Ok(());
-    }
-    
+    *watcher_guard = None;
+
     let app_handle_clone = handle.clone();
     let file_index_clone = state.file_index.clone();
     let asset_index_clone = state.asset_index.clone();
@@ -36,7 +34,7 @@ pub async fn watch_vault(
     let last_emit = Arc::new(Mutex::new(
         Instant::now() - Duration::from_millis(DEBOUNCE_MS),
     ));
-    
+
     let mut watcher = RecommendedWatcher::new(
         move |res: Result<Event, Error>| {
             match res {
@@ -45,7 +43,7 @@ pub async fn watch_vault(
                     let mut last = last_emit.lock().unwrap();
                     if last.elapsed() >= Duration::from_millis(DEBOUNCE_MS) {
                         *last = Instant::now();
-                        
+
                         // Invalidate caches
                         let fi = file_index_clone.clone();
                         let ai = asset_index_clone.clone();
@@ -64,12 +62,19 @@ pub async fn watch_vault(
         notify_config,
     )
         .map_err(|e| TessellumError::Internal(e.to_string()))?;
-    
+
     watcher
         .watch(Path::new(&vault_path), RecursiveMode::Recursive)
         .map_err(|e| TessellumError::Internal(e.to_string()))?;
-    
+
     *watcher_guard = Some(watcher);
-    
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn unwatch_vault(state: State<'_, AppState>) -> Result<(), TessellumError> {
+    let mut watcher_guard = state.watcher.lock().await;
+    *watcher_guard = None;
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,7 @@ pub fn run() {
             commands::clipboard::import_clipboard_files,
             commands::clipboard::write_file_paths_to_clipboard,
             commands::watcher::watch_vault,
+            commands::watcher::unwatch_vault,
             commands::vault::rename_file,
             commands::vault::move_items,
             commands::folders::create_folder,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,10 +37,12 @@ import { useApplyAccessibilitySettings } from "./hooks/useApplyAccessibilitySett
 import { useApplyThemeSchedule } from "./hooks/useApplyThemeSchedule";
 import { ColorFilterDefs } from "./components/Accessibility/ColorFilterDefs";
 import { useWorkspaceNavigationHistory } from "./hooks/useWorkspaceNavigationHistory";
+import { useApplySpellCheckSettings } from "./hooks/useApplySpellCheckSettings";
 import { useClipboardFilePaste } from "./features/clipboard/useClipboardFilePaste";
 import { useClipboardFileCopy } from "./features/clipboard/useClipboardFileCopy";
 import { shouldHandleClipboardFileCopyShortcut } from "./features/clipboard/clipboardCopyShortcut";
 import { resolveClipboardSelection } from "./features/clipboard/clipboardSelection";
+import { toSpellcheckLang } from "./i18n/spellcheck";
 
 const WINDOW_KEY = "tessellum-window";
 
@@ -67,7 +69,7 @@ function App() {
     const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
     const [isSettingsPanelOpen, setIsSettingsPanelOpen] = useState(false);
     const editorFontSizePx = useEditorContentStore((state) => state.editorFontSizePx);
-    const { fontFamily, editorLineHeight, editorLetterSpacing } = useSettingsStore();
+    const { fontFamily, editorLineHeight, editorLetterSpacing, locale } = useSettingsStore();
     const loadThemes = useThemeStore((state) => state.loadThemes);
     const startThemeWatch = useThemeStore((state) => state.startWatching);
     const stopThemeWatch = useThemeStore((state) => state.stopWatching);
@@ -80,6 +82,7 @@ function App() {
     useApplyAppearanceSettings();
     useApplyThemeSchedule();
     useApplyAccessibilitySettings();
+    useApplySpellCheckSettings();
     useWorkspaceNavigationHistory({ workspaceRestored });
 
     useEffect(() => {
@@ -472,6 +475,10 @@ function App() {
             console.error(e);
         }
     }
+
+    useEffect(() => {
+        document.documentElement.lang = toSpellcheckLang(locale);
+    }, [locale]);
 
     return (
         <TessellumAppContext.Provider value={app}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,7 +360,26 @@ function App() {
             setExpandedFolders({});
             setWorkspaceRestored(false);
         }
+
+        return () => {
+            invoke('unwatch_vault').catch(() => {
+                // Ignore teardown errors during dev reload/unmount.
+            });
+        };
     }, [vaultPath]);
+
+    useEffect(() => {
+        const onBeforeUnload = () => {
+            invoke('unwatch_vault').catch(() => {
+                // Ignore teardown errors during browser unload/HMR.
+            });
+        };
+
+        window.addEventListener('beforeunload', onBeforeUnload);
+        return () => {
+            window.removeEventListener('beforeunload', onBeforeUnload);
+        };
+    }, []);
 
     useEffect(() => {
         let syncTimer: number | null = null;
@@ -372,7 +391,12 @@ function App() {
                 invoke('sync_vault', { vaultPath }).catch(console.error);
             }, 400);
         });
-        return () => { unlistenPromise.then(unlisten => unlisten()); };
+        return () => {
+            if (syncTimer) {
+                window.clearTimeout(syncTimer);
+            }
+            unlistenPromise.then(unlisten => unlisten());
+        };
     }, [vaultPath]);
 
     useEffect(() => {

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -24,7 +24,7 @@ import { CalloutType } from "../../constants/callout-types";
 import { TessellumApp, useTessellumApp } from "../../plugins/TessellumApp";
 import { PaletteCommand } from "../../plugins/api/UIAPI";
 import { EditorView } from "@codemirror/view";
-import { Extension } from "@codemirror/state";
+import { Extension, Prec } from "@codemirror/state";
 import { Calendar, Clock } from "lucide-react";
 import { theme } from "../../styles/theme";
 import { isMediaFile } from "../../utils/fileType";
@@ -33,10 +33,11 @@ import { EDITOR_MODES } from "../../constants/editorModes";
 import { useEditorModeStore } from "../../stores/editorModeStore";
 import { markdownPreviewForceHideFacet } from "./extensions/markdown-preview-plugin";
 import { TabStrip, type Tab } from "./TabStrip";
-import { useAccessibilityStore } from "../../stores";
+import { useAccessibilityStore, useSettingsStore } from "../../stores";
 import { WorkspaceOverview } from "./workspaceOverview/WorkspaceOverview";
 import type { HeroProjection, WorkspaceCardItem } from "./workspaceOverview/types";
 import { useAppTranslation } from "../../i18n/react.tsx";
+import { toSpellcheckLang } from "../../i18n/spellcheck";
 import { SelectionToolbar } from "./toolbar/SelectionToolbar";
 import {
     applyMarkdownShortcut,
@@ -417,6 +418,8 @@ function EditorHeader({
                           lastModified,
                           titleFontSizePx,
                           readOnly,
+                          spellCheck,
+                          spellCheckLanguage,
                           t,
                           locale,
                       }: {
@@ -427,6 +430,8 @@ function EditorHeader({
     lastModified: number;
     titleFontSizePx: number;
     readOnly: boolean;
+    spellCheck: boolean;
+    spellCheckLanguage: string;
     t: (key: string, options?: Record<string, unknown>) => string;
     locale: string;
 }) {
@@ -449,6 +454,8 @@ function EditorHeader({
                     placeholder={t("editor.untitled")}
                     readOnly={readOnly}
                     disabled={readOnly}
+                    spellCheck={spellCheck}
+                    lang={spellCheckLanguage}
                 />
                 <div className="flex items-center gap-3 text-[0.6875rem] mt-5" style={{ color: theme.colors.text.muted, paddingBottom: 20 }}>
                     <span className="flex items-center gap-1">
@@ -619,6 +626,8 @@ export function Editor() {
     } = useEditorStore();
     const editorMode = useEditorModeStore((state) => state.editorMode);
     const reducedMotion = useAccessibilityStore((state) => state.reducedMotion);
+    const spellCheck = useSettingsStore((state) => state.spellCheck);
+    const appLocale = useSettingsStore((state) => state.locale);
     const { content, isLoading, handleContentChange } = useFileSynchronization(activeNote);
     const editorRef = useRef<ReactCodeMirrorRef>(null);
     const editorContainerRef = useRef<HTMLDivElement | null>(null);
@@ -773,9 +782,25 @@ export function Editor() {
     );
 
     const titleFontSizePx = useMemo(() => Math.round(28 * editorFontSizePx / 16), [editorFontSizePx]);
+    const spellCheckLanguage = useMemo(() => toSpellcheckLang(appLocale), [appLocale]);
     const isEditable = EDITOR_MODES[editorMode].editable;
     const selectionToolbarEnabled = isEditable && (editorMode === "live-preview" || editorMode === "source");
     const editableExtension = useMemo(() => EditorView.editable.of(isEditable), [isEditable]);
+    const spellCheckExtension = useMemo(
+        () => Prec.highest([
+            EditorView.editorAttributes.of({
+                spellcheck: spellCheck ? "true" : "false",
+                lang: spellCheckLanguage,
+                autocorrect: spellCheck ? "on" : "off",
+            }),
+            EditorView.contentAttributes.of({
+                spellcheck: spellCheck ? "true" : "false",
+                lang: spellCheckLanguage,
+                autocorrect: spellCheck ? "on" : "off",
+            }),
+        ]),
+        [spellCheck, spellCheckLanguage]
+    );
     const previewForceHideExtension = useMemo(
         () => markdownPreviewForceHideFacet.of(!isEditable),
         [isEditable]
@@ -784,6 +809,7 @@ export function Editor() {
         () => [
             ...pluginExtensions,
             editableExtension,
+            spellCheckExtension,
             previewForceHideExtension,
             slashExtension,
             wikiLinkSuggestionsExtension,
@@ -792,6 +818,7 @@ export function Editor() {
         [
             pluginExtensions,
             editableExtension,
+            spellCheckExtension,
             previewForceHideExtension,
             slashExtension,
             wikiLinkSuggestionsExtension,
@@ -967,6 +994,8 @@ export function Editor() {
                 titleFontSizePx={titleFontSizePx}
                 lastModified={activeNote.last_modified}
                 readOnly={!isEditable}
+                spellCheck={spellCheck}
+                spellCheckLanguage={spellCheckLanguage}
                 t={t}
                 locale={i18n.language}
             />

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -7,7 +7,8 @@ import { useAppTranslation } from "../../i18n/react.tsx";
 
 export function GeneralSettings() {
     const [autoSave, setAutoSave] = useState(true);
-    const [spellCheck, setSpellCheck] = useState(true);
+    const spellCheck = useSettingsStore((state) => state.spellCheck);
+    const setSpellCheck = useSettingsStore((state) => state.setSpellCheck);
     const locale = useSettingsStore((state) => state.locale);
     const setLocale = useSettingsStore((state) => state.setLocale);
     const { t } = useAppTranslation("settings");

--- a/src/hooks/useApplySpellCheckSettings.ts
+++ b/src/hooks/useApplySpellCheckSettings.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import { useSettingsStore } from "../stores";
+
+type SpellcheckElement = HTMLElement & { spellcheck?: boolean };
+
+const MANAGED_SELECTOR = "input, textarea, [contenteditable='true'], [contenteditable=''], [contenteditable='plaintext-only']";
+const TEXT_LIKE_INPUT_TYPES = new Set(["", "text", "search", "email", "url", "tel"]);
+
+function isSpellcheckTarget(element: HTMLElement): element is SpellcheckElement {
+    if (element instanceof HTMLTextAreaElement) return true;
+    if (element instanceof HTMLInputElement) {
+        return TEXT_LIKE_INPUT_TYPES.has(element.type.toLowerCase());
+    }
+    if (element.isContentEditable) return true;
+    return false;
+}
+
+function setSpellcheckOnElement(element: SpellcheckElement, enabled: boolean) {
+    if (!isSpellcheckTarget(element)) {
+        return;
+    }
+
+    element.spellcheck = enabled;
+    element.setAttribute("spellcheck", String(enabled));
+}
+
+function applySpellcheckToTree(root: ParentNode, enabled: boolean) {
+    if (root instanceof HTMLElement) {
+        setSpellcheckOnElement(root, enabled);
+    }
+
+    root.querySelectorAll<HTMLElement>(MANAGED_SELECTOR).forEach((element) => {
+        setSpellcheckOnElement(element, enabled);
+    });
+}
+
+function isSameValue(previous: boolean | null, next: boolean): boolean {
+    return previous !== null && previous === next;
+}
+
+export function useApplySpellCheckSettings() {
+    const lastApplied = useRef<boolean | null>(null);
+
+    useEffect(() => {
+        const applyIfChanged = (enabled: boolean, force = false) => {
+            if (!force && isSameValue(lastApplied.current, enabled)) {
+                return;
+            }
+
+            lastApplied.current = enabled;
+            applySpellcheckToTree(document, enabled);
+        };
+
+        applyIfChanged(useSettingsStore.getState().spellCheck, true);
+
+        const unsubscribe = useSettingsStore.subscribe((state) => {
+            applyIfChanged(state.spellCheck);
+        });
+
+        const observer = new MutationObserver((mutations) => {
+            const enabled = useSettingsStore.getState().spellCheck;
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (!(node instanceof HTMLElement)) return;
+                    applySpellcheckToTree(node, enabled);
+                });
+
+                if (mutation.type === "attributes" && mutation.target instanceof HTMLElement) {
+                    setSpellcheckOnElement(mutation.target, enabled);
+                }
+            });
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["contenteditable", "type"],
+        });
+
+        return () => {
+            unsubscribe();
+            observer.disconnect();
+        };
+    }, []);
+}
+

--- a/src/i18n/spellcheck.ts
+++ b/src/i18n/spellcheck.ts
@@ -1,0 +1,11 @@
+import type { AppLocale } from "./types";
+
+const SPELLCHECK_LANG_BY_LOCALE: Record<AppLocale, string> = {
+    en: "en-US",
+    es: "es-ES",
+};
+
+export function toSpellcheckLang(locale: AppLocale): string {
+    return SPELLCHECK_LANG_BY_LOCALE[locale] ?? "en-US";
+}
+

--- a/src/plugins/builtin/CoreUIActionsPlugin.tsx
+++ b/src/plugins/builtin/CoreUIActionsPlugin.tsx
@@ -167,19 +167,11 @@ export class CoreUIActionsPlugin extends Plugin {
             region: "sidebar-header",
             order: 20,
         });
-        this.app.ui.registerUIAction(this.manifest.id, {
-            id: "sidebar-paste-files",
-            label: () => t("actions.pasteFiles"),
-            icon: <Clipboard size={16} />,
-            onClick: pasteFiles,
-            region: "sidebar-header",
-            order: 30,
-        });
 
         this.app.ui.registerUIAction(this.manifest.id, {
             id: "sidebar-graph",
             label: () => t("actions.graphView"),
-            icon: <Network size={16} />,
+            icon: <Network size={16}/>,
             onClick: openGraph,
             region: "sidebar-footer",
             order: 10,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -7,6 +7,7 @@ const EDITOR_LETTER_SPACING_KEY = "tessellum:editorLetterSpacing";
 const LOCALE_KEY = "tessellum:locale";
 const VIM_MODE_KEY = "tessellum:vimMode";
 const LINE_NUMBERS_KEY = "tessellum:lineNumbers";
+const SPELL_CHECK_KEY = "tessellum:spellCheck";
 
 const DEFAULT_FONT_FAMILY = "Geist Sans";
 const DEFAULT_EDITOR_LINE_HEIGHT = 1.7;
@@ -14,6 +15,7 @@ const DEFAULT_EDITOR_LETTER_SPACING = 0;
 export const DEFAULT_LOCALE: AppLocale = "en";
 export const DEFAULT_VIM_MODE = false;
 export const DEFAULT_LINE_NUMBERS = false;
+export const DEFAULT_SPELL_CHECK = true;
 
 function readString(key: string, fallback: string): string {
     const raw = localStorage.getItem(key);
@@ -54,6 +56,7 @@ export interface SettingsState {
     locale: AppLocale;
     vimMode: boolean;
     lineNumbers: boolean;
+    spellCheck: boolean;
 }
 
 export interface SettingsActions {
@@ -63,6 +66,7 @@ export interface SettingsActions {
     setLocale: (value: AppLocale) => void;
     setVimMode: (value: boolean) => void;
     setLineNumbers: (value: boolean) => void;
+    setSpellCheck: (value: boolean) => void;
 }
 
 export type SettingsStore = SettingsState & SettingsActions;
@@ -74,6 +78,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     locale: readStoredLocale(),
     vimMode: readStoredVimMode(),
     lineNumbers: readBoolean(LINE_NUMBERS_KEY, DEFAULT_LINE_NUMBERS),
+    spellCheck: readBoolean(SPELL_CHECK_KEY, DEFAULT_SPELL_CHECK),
 
     setFontFamily: (fontFamily) => set(() => {
         localStorage.setItem(FONT_FAMILY_KEY, fontFamily);
@@ -98,5 +103,9 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     setLineNumbers: (lineNumbers) => set(() => {
         localStorage.setItem(LINE_NUMBERS_KEY, String(lineNumbers));
         return { lineNumbers };
+    }),
+    setSpellCheck: (spellCheck) => set(() => {
+        localStorage.setItem(SPELL_CHECK_KEY, String(spellCheck));
+        return { spellCheck };
     }),
 }));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1106,6 +1106,17 @@ body {
         color: var(--cm-hashtag);
         padding: 0 0.5rem !important;
     }
+
+    /* Keep native spellcheck markers visible inside CodeMirror tokens. */
+    .cm-editor ::spelling-error {
+        text-decoration: underline wavy #ef4444;
+        text-underline-offset: 0.12em;
+    }
+
+    .cm-editor ::grammar-error {
+        text-decoration: underline wavy #f59e0b;
+        text-underline-offset: 0.12em;
+    }
 }
 
 /* --- Accessibility Overrides --- */


### PR DESCRIPTION
This pull request introduces two significant updates:

1. **Vault Watcher Management**  
   - Added `unwatch_vault` command to release stale watchers during teardown.  
   - Updated `watch_vault` to prevent buildup of redundant watchers by replacing existing ones.  
   - Integrated proper cleanup in React's `useEffect` to invoke `unwatch_vault` on unmount and page unload.  
   - Removed the unused `sidebar-paste-files` UI action for a cleaner configuration.  

2. **Spell Check Functionality**  
   - Added spell check support integrated into editor settings, with persistent storage for user preferences.  
   - Enabled spellcheck for editable elements with localized language support.  
   - Applied native spellcheck markers using updated CSS.  
   - Added `useApplySpellCheckSettings` hook for dynamic spellcheck application.  
   - Enhanced CodeMirror extensions to honor spellcheck and language settings.