### PR TITLE
Add feature demo creator and improve file handling logic

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,6 +23,9 @@ pub use notes::{
 	trash_items, write_file, delete_trash_item_permanently,
 };
 pub use templates::{create_note_from_template, list_templates};
-pub use vault::{list_files, list_files_tree, move_items, rename_file, set_vault_path};
+pub use vault::{
+	ensure_feature_demo_in_empty_vault, list_files, list_files_tree, move_items, rename_file,
+	set_vault_path,
+};
 pub use watcher::{watch_vault, unwatch_vault};
 pub use search::{search_full_text, search_tags, rebuild_search_index};

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -12,6 +12,9 @@ use crate::search::SearchDoc;
 use crate::trash::purge_expired_trash;
 use crate::utils::{extract_tags, is_hidden_or_special, sanitize_string, validate_path_in_vault};
 
+const FEATURE_DEMO_FILENAME: &str = "FEATURE_DEMO.md";
+const FEATURE_DEMO_CONTENT: &str = include_str!("../../../FEATURE_DEMO.md");
+
 /// Rewrite `[[OldStem]]` and `[[OldStem|alias]]` to `[[NewStem]]` / `[[NewStem|alias]]`
 /// in all files whose paths are listed in `backlinks`.
 /// Escaped links (`\[[OldStem]]`) are left unchanged.
@@ -140,6 +143,31 @@ pub fn list_files(vault_path: String) -> Result<Vec<FileMetadata>, TessellumErro
     }
     
     Ok(files)
+}
+
+#[tauri::command]
+pub async fn ensure_feature_demo_in_empty_vault(vault_path: String) -> Result<bool, TessellumError> {
+    let vault = Path::new(&vault_path);
+    if !vault.exists() || !vault.is_dir() {
+        return Err(TessellumError::NotFound(
+            "Vault path does not exist".to_string(),
+        ));
+    }
+
+    if !list_files(vault_path.clone())?.is_empty() {
+        return Ok(false);
+    }
+
+    let demo_path = vault.join(FEATURE_DEMO_FILENAME);
+    if demo_path.exists() {
+        return Ok(false);
+    }
+
+    tokio::fs::write(demo_path, FEATURE_DEMO_CONTENT)
+        .await
+        .map_err(TessellumError::from)?;
+
+    Ok(true)
 }
 
 /// Asynchronous Tauri command to rename a file or folder.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,7 @@ pub fn run() {
             commands::templates::create_note_from_template,
             commands::vault::list_files,
             commands::vault::list_files_tree,
+            commands::vault::ensure_feature_demo_in_empty_vault,
             commands::clipboard::import_clipboard_files,
             commands::clipboard::write_file_paths_to_clipboard,
             commands::watcher::watch_vault,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -494,6 +494,10 @@ function App() {
 
     async function refreshFiles(vaultPath: string, restoreState: boolean): Promise<void> {
         try {
+            if (restoreState) {
+                await invoke<boolean>('ensure_feature_demo_in_empty_vault', { vaultPath });
+            }
+
             const [flatFiles, treeFiles] = await Promise.all([
                 invoke<FileMetadata[]>('list_files', { vaultPath }),
                 invoke<TreeNode[]>('list_files_tree', { vaultPath })


### PR DESCRIPTION
- Added `ensure_feature_demo_in_empty_vault` command to create demo files in empty vaults.
- Updated file refresh logic to support the creation of demo files when restoring state is enabled.
- Improved handling of file extensions, including preserving original extensions and addressing empty extension cases.
- Enhanced the logic for parsing trash names with expanded test coverage.